### PR TITLE
feat: Extend connection string support

### DIFF
--- a/DockerTools.ConsoleApp/DockerTools.ConsoleApp.csproj
+++ b/DockerTools.ConsoleApp/DockerTools.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/DockerTools.ConsoleApp/Program.cs
+++ b/DockerTools.ConsoleApp/Program.cs
@@ -48,6 +48,9 @@ public static class Program
             stopwatch.Stop();
             Console.WriteLine($"Instance {instance} initialization time: {stopwatch.ElapsedMilliseconds}ms");
         }
+        
+        Console.WriteLine($"Connection string: {container.ConnectionString}");
+        Console.WriteLine($"Connection string port: {container.ConnectionString.Port}");
 
         const string script = @"CREATE TABLE spatial_ref_sys2
 (

--- a/DockerTools/Containers/Container.cs
+++ b/DockerTools/Containers/Container.cs
@@ -17,7 +17,7 @@ public sealed class Container<T> : IContainer<T> where T : IContainerTemplate, n
     public string Id { get; }
 
     /// <inheritdoc />
-    public string ConnectionString { get; private set; }
+    public ConnectionString ConnectionString { get; private set; }
 
     internal Container(string id, DockerClient client, T containerTemplate, string hostPort)
     {

--- a/DockerTools/Containers/IContainer.cs
+++ b/DockerTools/Containers/IContainer.cs
@@ -20,7 +20,7 @@ public interface IContainer<T> : IAsyncDisposable, IDisposable where T : IContai
     /// <summary>
     /// The connection string to the database instance.
     /// </summary>
-    public string ConnectionString { get; }
+    public ConnectionString ConnectionString { get; }
 
     /// <summary>
     /// Run a script on the container's database.

--- a/DockerTools/Containers/Templates/IContainerTemplate.cs
+++ b/DockerTools/Containers/Templates/IContainerTemplate.cs
@@ -46,7 +46,7 @@ public interface IContainerTemplate
 
     internal Task<ScriptExecutionResult> PerformPostStartOperationsAsync(DockerClient client, string id, CancellationToken token);
 
-    internal string GetConnectionString(string hostPort);
+    internal ConnectionString GetConnectionString(string hostPort);
 
     internal Task<ScriptExecutionResult> RunScriptAsync(DockerClient client, string id, string script, CancellationToken token);
 }

--- a/DockerTools/Containers/Templates/Postgis.cs
+++ b/DockerTools/Containers/Templates/Postgis.cs
@@ -72,8 +72,16 @@ public sealed class Postgis : IContainerTemplate
         return Task.FromResult(new ScriptExecutionResult(null));
     }
 
-    string IContainerTemplate.GetConnectionString(string hostPort)
-        => $"Server=localhost;Port={hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Command Timeout=0;";
+    ConnectionString IContainerTemplate.GetConnectionString(string hostPort)
+    {
+        return new ConnectionString(
+            $"Server=localhost;Port={hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Command Timeout=0;",
+            hostPort,
+            this.Database,
+            this.Username,
+            this.Password
+        );
+    }
 
     Task<ScriptExecutionResult> IContainerTemplate.RunScriptAsync(DockerClient client, string id, string script, CancellationToken token)
     {

--- a/DockerTools/Containers/Templates/Postgres.cs
+++ b/DockerTools/Containers/Templates/Postgres.cs
@@ -72,8 +72,16 @@ public sealed class Postgres : IContainerTemplate
         return Task.FromResult(new ScriptExecutionResult(null));
     }
 
-    string IContainerTemplate.GetConnectionString(string hostPort)
-        => $"Server=localhost;Port={hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Command Timeout=0;";
+    ConnectionString IContainerTemplate.GetConnectionString(string hostPort)
+    {
+        return new ConnectionString(
+            $"Server=localhost;Port={hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Command Timeout=0;",
+            hostPort,
+            this.Database,
+            this.Username,
+            this.Password
+        );
+    }
 
     Task<ScriptExecutionResult> IContainerTemplate.RunScriptAsync(DockerClient client, string id, string script, CancellationToken token)
     {

--- a/DockerTools/Containers/Templates/SqlServer.cs
+++ b/DockerTools/Containers/Templates/SqlServer.cs
@@ -75,8 +75,16 @@ public sealed class SqlServer : IContainerTemplate
         return CommandExecutionOperations.RunScriptAsync(client, id, command, script, token);
     }
 
-    string IContainerTemplate.GetConnectionString(string hostPort)
-        => $"Server=::1,{hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Encrypt=false;";
+    ConnectionString IContainerTemplate.GetConnectionString(string hostPort)
+    {
+        return new ConnectionString(
+            $"Server=::1,{hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Encrypt=false;",
+            hostPort,
+            this.Database,
+            this.Username,
+            this.Password
+        );
+    }
 
     Task<ScriptExecutionResult> IContainerTemplate.RunScriptAsync(DockerClient client, string id, string script, CancellationToken token)
     {

--- a/DockerTools/Containers/Templates/SqlServerFTS.cs
+++ b/DockerTools/Containers/Templates/SqlServerFTS.cs
@@ -75,8 +75,16 @@ public sealed class SqlServerFTS : IContainerTemplate
         return CommandExecutionOperations.RunScriptAsync(client, id, command, script, token);
     }
 
-    string IContainerTemplate.GetConnectionString(string hostPort)
-        => $"Server=::1,{hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Encrypt=false;";
+    ConnectionString IContainerTemplate.GetConnectionString(string hostPort)
+    {
+        return new ConnectionString(
+            $"Server=::1,{hostPort};Database={this.Database};User Id={this.Username};Password={this.Password};Encrypt=false;",
+            hostPort,
+            this.Database,
+            this.Username,
+            this.Password
+        );
+    }
 
     Task<ScriptExecutionResult> IContainerTemplate.RunScriptAsync(DockerClient client, string id, string script, CancellationToken token)
     {

--- a/DockerTools/Containers/Templates/Valkyrie.cs
+++ b/DockerTools/Containers/Templates/Valkyrie.cs
@@ -38,9 +38,9 @@ internal class Valkyrie : IContainerTemplate
         return Task.FromResult(new ScriptExecutionResult(null));
     }
 
-    string IContainerTemplate.GetConnectionString(string hostPort)
+    ConnectionString IContainerTemplate.GetConnectionString(string hostPort)
     {
-        return string.Empty;
+        return new ConnectionString();
     }
 
     Task<ScriptExecutionResult> IContainerTemplate.RunScriptAsync(DockerClient client, string id, string script, CancellationToken token)

--- a/DockerTools/Models/ConnectionString.cs
+++ b/DockerTools/Models/ConnectionString.cs
@@ -1,0 +1,40 @@
+﻿namespace miguelcouteirorodrigues.DockerTools.Models;
+
+/// <summary>
+/// Holds information regarding the container's
+/// database's connection string.
+/// </summary>
+public class ConnectionString
+{
+    private readonly string _value;
+    
+    public string Database { get; }
+
+    public string Username { get; }
+
+    public string Password { get; }
+
+    public string Port { get; }
+
+    internal ConnectionString(string value, string port, string database, string username, string password)
+    {
+        _value = value;
+        Port = port;
+        Database = database;
+        Username = username;
+        Password = password;
+    }
+
+    internal ConnectionString()
+    {
+        _value = string.Empty;
+        Port = string.Empty;
+        Database = string.Empty;
+        Username = string.Empty;
+        Password = string.Empty;
+    }
+    
+    public override string ToString() => _value;
+    
+    public static implicit operator string(ConnectionString connectionString) => connectionString.ToString();
+}


### PR DESCRIPTION
Connection string is now an object that exposes the port, database name, username, and password. It implicitely converts to a string to ensure backwards compatibility.